### PR TITLE
Include dollar sign in parameter name

### DIFF
--- a/Syntaxes/ActionScript 3.tmLanguage
+++ b/Syntaxes/ActionScript 3.tmLanguage
@@ -1888,7 +1888,7 @@
 			</dict>
 			<key>match</key>
 			<string>(?x)
-					 (\w+)          # paramater name
+					 (\$?\w+)       # paramater name
 					 \s*(\:)\s*     # type seperator
 					 (
 						(\w+)


### PR DESCRIPTION
When you use a parameter name starting with a dollar sign, it doesn't color with the rest of the word.

E.g. 
private function example( $parameter:\* ):void { }
