### PR TITLE
Remove indentNextLinePattern

### DIFF
--- a/Preferences/Indentation Rules.tmPreferences
+++ b/Preferences/Indentation Rules.tmPreferences
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>name</key>
@@ -12,8 +12,6 @@
 		<string>^(.*\*/)?\s*\}([^}{"']*\{)?[;\s]*(//.*|/\*.*\*/\s*)?$|^\s*(public|final|dynamic|internal):\s*$</string>
 		<key>increaseIndentPattern</key>
 		<string>^.*\{[^}"']*$|^\s*(public|final|dynamic|internal):\s*$</string>
-		<key>indentNextLinePattern</key>
-		<string>^(?!(.*[};:])?\s*(//|/\*.*\*/\s*$)).*[^\s;:{}]\s*$</string>
 	</dict>
 	<key>uuid</key>
 	<string>2ED58FB2-1E8C-4123-8EE7-217D14F04151</string>


### PR DESCRIPTION
According to the language guide* the semicolon at the end of statements is optional, this makes indentNextLinePattern match at unwanted times when leaving out the semicolon.

* https://help.adobe.com/en_US/as3/learn/WS5b3ccc516d4fbf351e63e3d118a9b90204-7f9b.html

Initially reported on Twitter by another user.